### PR TITLE
Fix Notion pinned CSS bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "sportswear",
+    "name": "IS207-Sportswear-Business-Website",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/public/assets/css/shared/footer.css
+++ b/public/assets/css/shared/footer.css
@@ -1,3 +1,7 @@
+.footer-padding{
+    width: 100%;
+    height: 100px;
+}
 .footer {
     background-color: black;
     color: #ccc;

--- a/public/assets/css/user/home.css
+++ b/public/assets/css/user/home.css
@@ -395,6 +395,18 @@ button {
     object-position: auto;
 }
 
+.ListImgContainer{
+    overflow: hidden;
+}
+
+.ListImgContainer img{
+    transition: all 0.4s ease;
+}
+.ListImgContainer img:hover{
+    transform: scale(1.2);
+}
+
+
 /* Scrollbar CSS */
 body::-webkit-scrollbar-track {
     -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);

--- a/public/assets/css/user/product_list.css
+++ b/public/assets/css/user/product_list.css
@@ -106,6 +106,7 @@ article {
     display: flex;
     justify-content: flex-end;
     align-items: center;
+    padding: 10px 0;
 }
 
 /* Sort products title */
@@ -117,8 +118,10 @@ article {
 /* Sort products combo box */
 .show-product-list-sort select {
     /* font-family: 'my_public_sans'; */
-    padding: 8px 10px;
+    padding: 8px 14px;
     outline: none;
+    border: solid 2px black;
+    margin-left: 10px;
 }
 
 /* Product list container */
@@ -153,32 +156,6 @@ div.product-img {
     font-weight: bold;
 }
 
-/* "Show more" button */
-.show-product-list-more {
-    display: flex;
-    justify-content: center;
-    padding-top: 2em;
-    padding-bottom: 2em;
-}
-
-.show-product-list-more button {
-    line-height: 2.5em;
-    font-weight: bold;
-    background-color: inherit;
-    /* font-family: 'my_public_sans'; */
-    padding-left: 1em;
-    padding-right: 1em;
-    cursor: pointer;
-}
-
-.show-product .product-name,
-.show-product .product-price {
-    text-align: left;
-    width: 100%;
-    padding-left: 2rem;
-    line-height: 1.25rem;
-}
-
 .hidden {
     display: none;
 }
@@ -187,18 +164,23 @@ div.product-img {
 .show-product-list-more {
     display: flex;
     justify-content: center;
-    padding-top: 2em;
-    padding-bottom: 2em;
+    padding: 2em 0;
 }
 
 .show-product-list-more button {
     line-height: 2.5em;
     font-weight: bold;
+    font-size: 14px;
     background-color: inherit;
     font-family: 'my_public_sans';
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 0.3em 2em;
     cursor: pointer;
+    border: solid 3px black;
+    transition: all 0.2s ease;
+}
+.show-product-list-more button:hover{
+    background-color: black;
+    color: aliceblue;
 }
 
 .show-product .product-name,
@@ -213,25 +195,44 @@ div.product-img {
 .show-product:hover {
     cursor: pointer;
     border-radius: 10px;
+    opacity: 1;
 }
 
 .show-product {
     padding: 10px;
     text-align: center;
+    overflow: hidden;
+    opacity: 0.9;
+}
+
+.product-img {
+    overflow: hidden;
+    width: 77%;
 }
 
 .show-product img {
+    width: 100%;
     margin-bottom: 10px;
     height: 15rem;
+    transition: all 0.2s ease;
 }
 
 
 .show-product:hover img {
     transform: scale(1.1);
-    transition: all .2s ease-in-out;
 }
 
 .apply-filter-btn {
     padding: 5px 10px;
     cursor: pointer;
+}
+
+.filter-values{
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    user-select: none;
+}
+.filter-values:hover label{
+    font-weight: bold;
 }

--- a/resources/views/shared/footer.blade.php
+++ b/resources/views/shared/footer.blade.php
@@ -1,3 +1,4 @@
+<div class="footer-padding"></div>
 <footer class="footer">
     <div class="footer-container">
         <div class="footer-grid__row">

--- a/resources/views/user/home.blade.php
+++ b/resources/views/user/home.blade.php
@@ -1,188 +1,202 @@
 @extends('layouts.app')
 @section('css')
-    <link rel="stylesheet" href=" {{ asset('assets/css/base.css') }} ">
-    <link rel="stylesheet" href=" {{ asset('assets/css/user/home.css') }} ">
-    <link rel="stylesheet" href=" {{ asset('assets/css/shared/carousel_pro.css') }} ">
-    <link rel="stylesheet" href=" {{ asset('assets/css/shared/marquee.css') }} ">
-    <link rel="stylesheet" href=" {{ asset('assets/css/shared/marquee_shirt.css') }} ">
+<link rel="stylesheet" href=" {{ asset('assets/css/base.css') }} ">
+<link rel="stylesheet" href=" {{ asset('assets/css/user/home.css') }} ">
+<link rel="stylesheet" href=" {{ asset('assets/css/shared/carousel_pro.css') }} ">
+<link rel="stylesheet" href=" {{ asset('assets/css/shared/marquee.css') }} ">
+<link rel="stylesheet" href=" {{ asset('assets/css/shared/marquee_shirt.css') }} ">
 @endsection
 @section('content')
-    <div class="homePage">
-        <div class="homePoster">
-            @include('shared.carousel_pro')
+<div class="homePage">
+    <div class="homePoster">
+        @include('shared.carousel_pro')
+    </div>
+    @include('shared.marquee')
+    <div class="homeCategory">
+        <div>
+            <p>HẠNG MỤC</p>
         </div>
-        @include('shared.marquee')
-        <div class="homeCategory">
-            <div>
-                <p>HẠNG MỤC</p>
-            </div>
-            <div class="homeListCategory">
-                <div onclick="window.location.href = '/products/new'" class="cursor-pointer">
+        <div class="homeListCategory">
+            <div onclick="window.location.href = '/products/new'" class="cursor-pointer">
+                <div class="ListImgContainer">
                     <img src="https://images.pexels.com/photos/13450843/pexels-photo-13450843.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                         alt="SẢN PHẨM MỚI">
-                    <h4>SẢN PHẨM MỚI</h4>
                 </div>
-                <div onclick="window.location.href = '/products/new?object=1'" class="cursor-pointer">
+                <h4>SẢN PHẨM MỚI</h4>
+            </div>
+            <div onclick="window.location.href = '/products/new?object=1'" class="cursor-pointer">
+                <div class="ListImgContainer">
                     <img src="https://images.pexels.com/photos/8556754/pexels-photo-8556754.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                         alt="SẢN PHẨM DÀNH CHO NAM">
-                    <h4>NAM</h4>
                 </div>
-                <div onclick="window.location.href = '/products/new?object=2'" class="cursor-pointer">
+                <h4>NAM</h4>
+            </div>
+            <div onclick="window.location.href = '/products/new?object=2'" class="cursor-pointer">
+                <div class="ListImgContainer">
                     <img src="https://images.pexels.com/photos/5300913/pexels-photo-5300913.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                         alt="SẢN PHẨM DÀNH CHO NỮ">
-                    <h4>NỮ</h4>
                 </div>
-                <div onclick="window.location.href = '/products/new?object=3'" class="cursor-pointer">
+                <h4>NỮ</h4>
+            </div>
+            <div onclick="window.location.href = '/products/new?object=3'" class="cursor-pointer">
+                <div class="ListImgContainer">
                     <img src="https://images.pexels.com/photos/5896837/pexels-photo-5896837.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                         alt="SẢN PHẨM DÀNH CHO TRẺ EM">
-                    <h4>TRẺ EM</h4>
                 </div>
-                <div onclick="window.location.href = '/products/new'" class="cursor-pointer">
+                <h4>TRẺ EM</h4>
+            </div>
+            <div onclick="window.location.href = '/products/new'" class="cursor-pointer">
+                <div class="ListImgContainer">
                     <img src="https://images.pexels.com/photos/9400764/pexels-photo-9400764.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                         alt="SẢN PHẨM ĐANG KHUYẾN MÃI">
-                    <h4>KHUYẾN MÃI</h4>
                 </div>
+                <h4>KHUYẾN MÃI</h4>
             </div>
         </div>
-        <div class="homeBanner">
-            <div class="homeBannerDescribe">
-                <p class="mb1 mt2">ÁO ĐẤU CHÍNH HÃNG</p>
-                <p class="mb2">Sở hữu cho mình những chiếc áo đấu mới mùa giải 2023/2024 của mọi câu lạc bộ thuộc Top 5
-                    Giải đấu hàng đầu thế giới. </p>
-                 @include('shared.marquee_shirt')
-                <button onclick="window.location.href='/products/new'" class="homeBannerBtn primary-button-hover" >XEM CHI TIẾT</button>
-            </div>
-            <div>
-                <img src="{{ asset('assets/images/module-3/image-png') }}" alt="">
-            </div>
-        </div>
-        <div class="homeNewestProduct">
-            <div>
-                <p>SẢN PHẨM HOT NHẤT</p>
-            </div>
-            <div class="homeNewestProductImg">
-                @foreach($products as $product)
-                <img class="cursor-pointer" onclick="window.location.href='/product/{{ $product->id }}'" src="{{ $product->images[0]->image_link }}}}"
-                    alt="GIÀY ĐÁ BÓNG MỚI NHẤT">
-                {{-- <img src="https://i.pinimg.com/564x/3c/a8/e5/3ca8e5a7e8509b84dd31620e22544065.jpg"
-                    alt="GIÀY ĐÁ BÓNG MỚI NHẤT">
-                <img src="https://images.unsplash.com/photo-1616124619460-ff4ed8f4683c?q=80&w=1898&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-                    alt="ÁO ĐẤU CHÍNH HÃNG MÙA GIẢI MỚI NHẤT">
-                <img src="https://i.pinimg.com/736x/ad/47/9d/ad479d5aaa731d35d8c2e09ee06a073d.jpg"
-                    alt="BỘ SƯU TẬP GIÀY CR7 MỚI NHẤT"> --}}
-                @endforeach
-            </div>
-        </div>
-
-        <div class="homeRate">
-            <div>
-                <p>ĐÁNH GIÁ CỦA KHÁCH HÀNG</p>
-            </div>
-            <div class="homeRateImg">
-                <img src="{{ asset('assets/images/module-5/customer-Review-1.png') }}" alt="ĐÁNH GIÁ TUYỆT VỜI TỪ KHÁCH HÀNG">
-                <img src="{{ asset('assets/images/module-5/customer-Review.png') }}" alt="ĐÁNH GIÁ TUYỆT VỜI TỪ KHÁCH HÀNG">
-                <img src="{{ asset('assets/images/module-5/customer-Review-1.png') }}" alt="ĐÁNH GIÁ TUYỆT VỜI TỪ KHÁCH HÀNG">
-            </div>
-        </div>
-
-        <div class="homeMen">
-            <div>
-                <p>NAM</p>
-            </div>
-            <div class="homeMenList">
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/52/8b/c1/528bc16d7e3dd205537ac86bbb30f76b.jpg"
-                            alt="SNEAKERS">
-                    </div>
-                    <h4>SNEAKERS</h4>
-                </div>
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/736x/9b/29/a8/9b29a8248a85e523f5136cdb9ce17cad.jpg"
-                            alt="GIÀY ĐÁ BÓNG">
-                    </div>
-                    <h4>GIÀY ĐÁ BÓNG</h4>
-                </div>
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/fd/30/9c/fd309c63499ca24dec16ade7de27bfd6.jpg"
-                            alt="ÁO QUẦN THỂ THAO CHO NAM">
-                    </div>
-                    <h4>ÁO QUẦN THỂ THAO </h4>
-                </div>
-            </div>
-            <div>
-                <button onclick="window.location.href='/products?object=1'" class="homeMenBtn primary-button-hover">XEM CHI TIẾT</button>
-            </div>
-        </div>
-        <div class="homeWomen">
-            <div>
-                <p>NỮ</p>
-            </div>
-            <div class="homeWomenList">
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/da/8a/cf/da8acff9d7ad524034fb16f3286b06bb.jpg"
-                            alt="SNEAKERS">
-                    </div>
-                    <h4>SNEAKERS</h4>
-                </div>
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/5e/3a/c1/5e3ac1112fcb2709e1173e5a33a2174d.jpg"
-                            alt="SPORT UNDERWEARS">
-                    </div>
-                    <h4>SPORT UNDERWEAR</h4>
-                </div>
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/a5/4e/58/a54e583e2ef19a26168acc2dcc37be8c.jpg"
-                            alt="ÁO QUẦN THỂ THAO CHO NỮ">
-                    </div>
-                    <h4>ÁO QUẦN THỂ THAO</h4>
-                </div>
-            </div>
-            <div>
-                <button onclick="window.location.href='/products?object=2'" class="homeWomenBtn primary-button-hover">XEM CHI TIẾT</button>
-            </div>
-        </div>
-        <div class="homeKids">
-            <div>
-                <p>TRẺ EM</p>
-            </div>
-            <div class="homeKidsList">
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/a3/0c/10/a30c10d7582e307820320d7ab4f08401.jpg"
-                            alt="SNEAKERS">
-                    </div>
-                    <h4>SNEAKERS</h4>
-                </div>
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/8a/f0/1b/8af01b800e2e7bf76178e3ca077d3b3b.jpg"
-                            alt="PHỤ KIỆN THỂ THAO CHO BÉ">
-                    </div>
-                    <h4>PHỤ KIỆN</h4>
-                </div>
-                <div class="homeListItem">
-                    <div class="homeListImg">
-                        <img src="https://i.pinimg.com/564x/e3/ed/86/e3ed86a2942789ed82274c884ad824b2.jpg"
-                            alt="ÁO QUẦN THỂ THAO CHO TRỂ EM">
-                    </div>
-                    <h4>ÁO QUẦN THỂ THAO</h4>
-                </div>
-            </div>
-            <div>
-                <button onclick="window.location.href='/products?object=3'" class="homeKidsBtn primary-button-hover">XEM CHI TIẾT</button>
-            </div>
-        </div>
-
     </div>
+    <div class="homeBanner">
+        <div class="homeBannerDescribe">
+            <p class="mb1 mt2">ÁO ĐẤU CHÍNH HÃNG</p>
+            <p class="mb2">Sở hữu cho mình những chiếc áo đấu mới mùa giải 2023/2024 của mọi câu lạc
+                bộ thuộc Top 5
+                Giải đấu hàng đầu thế giới. </p>
+            @include('shared.marquee_shirt')
+            <button onclick="window.location.href='/products/new'" class="homeBannerBtn primary-button-hover">XEM CHI
+                TIẾT</button>
+        </div>
+        <div>
+            <img src="{{ asset('assets/images/module-3/image-png') }}" alt="">
+        </div>
+    </div>
+    <div class="homeNewestProduct">
+        <div>
+            <p>SẢN PHẨM HOT NHẤT</p>
+        </div>
+        <div class="homeNewestProductImg">
+            @foreach($products as $product)
+            <img class="cursor-pointer" onclick="window.location.href='/product/{{ $product->id }}'"
+                src="{{ $product->images[0]->image_link }}}}" alt="GIÀY ĐÁ BÓNG MỚI NHẤT">
+            {{-- <img src="https://i.pinimg.com/564x/3c/a8/e5/3ca8e5a7e8509b84dd31620e22544065.jpg"
+                alt="GIÀY ĐÁ BÓNG MỚI NHẤT">
+            <img src="https://images.unsplash.com/photo-1616124619460-ff4ed8f4683c?q=80&w=1898&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                alt="ÁO ĐẤU CHÍNH HÃNG MÙA GIẢI MỚI NHẤT">
+            <img src="https://i.pinimg.com/736x/ad/47/9d/ad479d5aaa731d35d8c2e09ee06a073d.jpg"
+                alt="BỘ SƯU TẬP GIÀY CR7 MỚI NHẤT"> --}}
+            @endforeach
+        </div>
+    </div>
+
+    <div class="homeRate">
+        <div>
+            <p>ĐÁNH GIÁ CỦA KHÁCH HÀNG</p>
+        </div>
+        <div class="homeRateImg">
+            <img src="{{ asset('assets/images/module-5/customer-Review-1.png') }}"
+                alt="ĐÁNH GIÁ TUYỆT VỜI TỪ KHÁCH HÀNG">
+            <img src="{{ asset('assets/images/module-5/customer-Review.png') }}" alt="ĐÁNH GIÁ TUYỆT VỜI TỪ KHÁCH HÀNG">
+            <img src="{{ asset('assets/images/module-5/customer-Review-1.png') }}"
+                alt="ĐÁNH GIÁ TUYỆT VỜI TỪ KHÁCH HÀNG">
+        </div>
+    </div>
+
+    <div class="homeMen">
+        <div>
+            <p>NAM</p>
+        </div>
+        <div class="homeMenList">
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/52/8b/c1/528bc16d7e3dd205537ac86bbb30f76b.jpg" alt="SNEAKERS">
+                </div>
+                <h4>SNEAKERS</h4>
+            </div>
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/736x/9b/29/a8/9b29a8248a85e523f5136cdb9ce17cad.jpg"
+                        alt="GIÀY ĐÁ BÓNG">
+                </div>
+                <h4>GIÀY ĐÁ BÓNG</h4>
+            </div>
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/fd/30/9c/fd309c63499ca24dec16ade7de27bfd6.jpg"
+                        alt="ÁO QUẦN THỂ THAO CHO NAM">
+                </div>
+                <h4>ÁO QUẦN THỂ THAO </h4>
+            </div>
+        </div>
+        <div>
+            <button onclick="window.location.href='/products?object=1'" class="homeMenBtn primary-button-hover">XEM CHI
+                TIẾT</button>
+        </div>
+    </div>
+    <div class="homeWomen">
+        <div>
+            <p>NỮ</p>
+        </div>
+        <div class="homeWomenList">
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/da/8a/cf/da8acff9d7ad524034fb16f3286b06bb.jpg" alt="SNEAKERS">
+                </div>
+                <h4>SNEAKERS</h4>
+            </div>
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/5e/3a/c1/5e3ac1112fcb2709e1173e5a33a2174d.jpg"
+                        alt="SPORT UNDERWEARS">
+                </div>
+                <h4>SPORT UNDERWEAR</h4>
+            </div>
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/a5/4e/58/a54e583e2ef19a26168acc2dcc37be8c.jpg"
+                        alt="ÁO QUẦN THỂ THAO CHO NỮ">
+                </div>
+                <h4>ÁO QUẦN THỂ THAO</h4>
+            </div>
+        </div>
+        <div>
+            <button onclick="window.location.href='/products?object=2'" class="homeWomenBtn primary-button-hover">XEM
+                CHI TIẾT</button>
+        </div>
+    </div>
+    <div class="homeKids">
+        <div>
+            <p>TRẺ EM</p>
+        </div>
+        <div class="homeKidsList">
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/a3/0c/10/a30c10d7582e307820320d7ab4f08401.jpg" alt="SNEAKERS">
+                </div>
+                <h4>SNEAKERS</h4>
+            </div>
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/8a/f0/1b/8af01b800e2e7bf76178e3ca077d3b3b.jpg"
+                        alt="PHỤ KIỆN THỂ THAO CHO BÉ">
+                </div>
+                <h4>PHỤ KIỆN</h4>
+            </div>
+            <div class="homeListItem">
+                <div class="homeListImg">
+                    <img src="https://i.pinimg.com/564x/e3/ed/86/e3ed86a2942789ed82274c884ad824b2.jpg"
+                        alt="ÁO QUẦN THỂ THAO CHO TRỂ EM">
+                </div>
+                <h4>ÁO QUẦN THỂ THAO</h4>
+            </div>
+        </div>
+        <div>
+            <button onclick="window.location.href='/products?object=3'" class="homeKidsBtn primary-button-hover">XEM CHI
+                TIẾT</button>
+        </div>
+    </div>
+
+</div>
 @endsection
 @section('js')
-    <script src="{{ asset('assets/js/shared/marquee_shirt.js') }}"></script>
-    <script src="{{ asset('assets/js/shared/carousel_pro.js') }}"></script>
-    <script src="{{ asset('assets/js/shared/marquee.js') }}"></script>
+<script src="{{ asset('assets/js/shared/marquee_shirt.js') }}"></script>
+<script src="{{ asset('assets/js/shared/carousel_pro.js') }}"></script>
+<script src="{{ asset('assets/js/shared/marquee.js') }}"></script>
 @endsection

--- a/resources/views/user/product_list.blade.php
+++ b/resources/views/user/product_list.blade.php
@@ -21,17 +21,17 @@
                     @foreach ($filter_values as $key => $value)
 
                     @if (in_array($value['item'], $data['filter_checked']))
-                        <div class="filter-values">
-                            <input type="checkbox" checked>
-                            <label>{{ $value['item'] }}</label>
-                            <br>
-                        </div>
+                    <div class="filter-values">
+                        <input type="checkbox" id="<?= $value['item'] ?>" checked>
+                        <label for="<?= $value['item'] ?>">{{ $value['item'] }}</label>
+                        <br>
+                    </div>
                     @else
-                        <div class="filter-values">
-                            <input type="checkbox">
-                            <label>{{ $value['item'] }}</label>
-                            <br>
-                        </div>
+                    <div class="filter-values">
+                        <input type="checkbox" id="<?= $value['item'] ?>" />
+                        <label for="<?= $value['item'] ?>">{{ $value['item'] }}</label>
+                        <br>
+                    </div>
                     @endif
 
                     @endforeach
@@ -39,7 +39,7 @@
                 <br>
                 @endforeach
                 <br>
-                <button class="apply-filter-btn">Áp dụng bộ lọc</button>
+                <button class=" apply-filter-btn">Áp dụng bộ lọc</button>
 
         </aside>
 
@@ -61,12 +61,14 @@
                 <div class="show-product" onclick="window.location.href='/product/{{ $product->id }}'">
                     <div class="product-img">
                         @if ($product->images->isNotEmpty())
-                            @foreach ($product->images as $image)
-                                <img class="product-img-inner" src="{{ $image->image_link }}" alt="product-img">
-                                @break
+                        @foreach ($product->images as $image)
+                        <img class="product-img-inner" src="{{ $image->image_link }}" alt="product-img">
+                        @break
                         @endforeach
                         @else
-                            <img class="product-img-inner" src="https://st3.depositphotos.com/17828278/33150/v/450/depositphotos_331503262-stock-illustration-no-image-vector-symbol-missing.jpg" alt="product-img">
+                        <img class="product-img-inner"
+                            src="https://st3.depositphotos.com/17828278/33150/v/450/depositphotos_331503262-stock-illustration-no-image-vector-symbol-missing.jpg"
+                            alt="product-img">
                         @endif
                     </div>
                     <div class="product-name">{{ $product->product_name }}</div>


### PR DESCRIPTION
- [x]  Product list:
    - [x]  Chỉnh lại phần bộ lọc cho giống figma, css lại nút áp dụng bộ lọc
    - [x]  Khi ấn vào các tên bộ lọc thì sẽ tự động tick vào checkbox
    - [x]  css lại drop down "sắp xếp theo", nút hiển thị thêm sản phẩm
    - [x]  Hình ảnh khi rê vào thì phóng to như trong the band
    - [x]  Tên sản phẩm vào giá thẳng hàng căn trái với hình ảnh
    - [x]  Khi không có nút Hiển thị thêm thì chân trang quá sát phần body
    - [x]  Hình ảnh khi rê vào thì phóng to
- [x]  Trang chủ
    - [x]  Hình ảnh khi rê vào thì phóng to